### PR TITLE
Bug fix

### DIFF
--- a/client/src/components/Chat/Chat.js
+++ b/client/src/components/Chat/Chat.js
@@ -202,10 +202,10 @@ function Chat() {
   return (
     <Wrapper>
       {/* Order Buttons */}
-      <OrderMenu />
-      <div>
+      <OrderMenu aria-label="메뉴"/>
+      <div aria-label="키위봇과 대화하는 채팅창입니다">
         {/* Chat Messages */}
-        <Messages>{renderMessages(messagesFromRedux)}</Messages>
+        <Messages >{renderMessages(messagesFromRedux)}</Messages>
         {/* Input Field and Button */}
         <Paper
           component="form"
@@ -220,7 +220,7 @@ function Chat() {
             value={Input}
             onChange={inputHandler}
           />
-          <Button variant="contained" className={classes.button} type="submit">
+          <Button variant="contained" className={classes.button} type="submit" aria-label="메시지 보내기">
             <SendIcon />
           </Button>
         </Paper>

--- a/client/src/components/Chat/Sections/OrderMenu.js
+++ b/client/src/components/Chat/Sections/OrderMenu.js
@@ -37,12 +37,13 @@ function OrderMenu() {
   };
 
   return (
-    <MenuComponent>
+    <MenuComponent >
       {/* 메뉴 버튼 */}
       <CustomButton onClick={handleOpenMenu}>메뉴</CustomButton>
       <Dialog
         open={openMenu}
         onClose={handleCloseMenu}
+        aria-label="메뉴버튼 바입니다"
         aria-labelledby="menu-title"
         aria-describedby="menu-description"
       >
@@ -66,9 +67,9 @@ function OrderMenu() {
         aria-labelledby="event-title"
         aria-describedby="event-description"
       >
-        <DialogTitle id="event-title">{"키위 오픈 기념 이벤트"}</DialogTitle>
-        <DialogContent>
-          <DialogContentText id="event-description">
+        <DialogTitle id="event-title" >{"키위 오픈 기념 이벤트"}</DialogTitle>
+        <DialogContent >
+          <DialogContentText id="event-description" >
             고려대학교 학식 키위로 결제시 5% 할인
           </DialogContentText>
         </DialogContent>
@@ -79,7 +80,7 @@ function OrderMenu() {
         </DialogActions>
       </Dialog>
       {/* 직원호출 버튼 */}
-      <CustomButton onClick={handleOpenCall}>직원호출</CustomButton>
+      <CustomButton onClick={handleOpenCall} >직원호출</CustomButton>
       <Dialog
         open={openCall}
         onClose={handleCloseCall}

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -90,6 +90,7 @@ function Header(props) {
           <a href="/" className={classes.title}>
             <img
               alt="키위 로고"
+              aria-label="키위 홈으로"
               src={KiweHeaderIcon}
               style={{ height: "28px" }}
             />

--- a/client/src/components/LandingPage/Sections/MiddleOne.js
+++ b/client/src/components/LandingPage/Sections/MiddleOne.js
@@ -50,7 +50,7 @@ function MiddleOne() {
   return (
     <MiddleOneBlock>
       <div>
-        <img src={kiweDetail} alt="kiwe-landing-page-image" className="img" />
+        <img src={kiweDetail} alt="키위 소개" aria-hidden="true" className="img" />
         <div className="sub-header">
           <h3>함께하는 키오스크 키위가 질문합니다.</h3>
         </div>

--- a/client/src/components/LandingPage/Sections/Top.js
+++ b/client/src/components/LandingPage/Sections/Top.js
@@ -61,13 +61,13 @@ function Top(props) {
         <Grid container>
           <Grid item xs={12} sm={6} align="center">
             <div>
-              <img src={kiweLanding} alt="kiwe-landing-page-image" />
+              <img src={kiweLanding} alt="키위소개" aria-hidden="true" />
             </div>
           </Grid>
           <Grid item xs={12} sm={6} align="center">
             <div>
               <div className="title-block">
-                <h3>Kiosk We: </h3>
+                <h3 aria-label="키오스크 위">Kiosk + We: </h3>
                 <h3>함께하는 키오스크 키위.</h3>
 
                 <div className="sub-title">

--- a/client/src/components/TutorialPage/TutorialPage.js
+++ b/client/src/components/TutorialPage/TutorialPage.js
@@ -40,7 +40,7 @@ export default function TutorialPage(props) {
             <CardActionArea>
               <CardMedia
                 component="img"
-                alt="첫번째 가이드"
+                alt="첫번째 가이드."
                 height="130"
                 image={chatImg}
                 title="guide"
@@ -50,6 +50,7 @@ export default function TutorialPage(props) {
                   className={classes.title}
                   color="textSecondary"
                   gutterBottom
+                  aria-hidden="true"
                 >
                   시작 가이드 1
                 </Typography>
@@ -71,7 +72,7 @@ export default function TutorialPage(props) {
             <CardActionArea>
               <CardMedia
                 component="img"
-                alt="두번째 가이드"
+                alt="두번째 가이드."
                 height="130"
                 image={restImg}
                 title="guide"
@@ -81,6 +82,7 @@ export default function TutorialPage(props) {
                   className={classes.title}
                   color="textSecondary"
                   gutterBottom
+                  aria-hidden="true"
                 >
                   시작 가이드 2
                 </Typography>
@@ -102,7 +104,7 @@ export default function TutorialPage(props) {
             <CardActionArea>
               <CardMedia
                 component="img"
-                alt="세번째 가이드"
+                alt="세번째 가이드."
                 height="130"
                 image={foodImg}
                 title="guide"
@@ -112,6 +114,7 @@ export default function TutorialPage(props) {
                   className={classes.title}
                   color="textSecondary"
                   gutterBottom
+                  aria-hidden="true"
                 >
                   시작 가이드 3
                 </Typography>
@@ -133,7 +136,7 @@ export default function TutorialPage(props) {
             <CardActionArea>
               <CardMedia
                 component="img"
-                alt="네번째 가이드"
+                alt="네번째 가이드."
                 height="130"
                 image={byeImg}
                 title="guide"
@@ -143,6 +146,7 @@ export default function TutorialPage(props) {
                   className={classes.title}
                   color="textSecondary"
                   gutterBottom
+                  aria-hidden="true"
                 >
                   시작 가이드 4
                 </Typography>
@@ -164,7 +168,7 @@ export default function TutorialPage(props) {
             <CardActionArea>
               <CardMedia
                 component="img"
-                alt="다섯번째 가이드"
+                alt="다섯번째 가이드."
                 height="130"
                 image={restImg}
                 title="guide"
@@ -174,6 +178,7 @@ export default function TutorialPage(props) {
                   className={classes.title}
                   color="textSecondary"
                   gutterBottom
+                  aria-hidden="true"
                 >
                   시작 가이드 5
                 </Typography>
@@ -195,7 +200,7 @@ export default function TutorialPage(props) {
             <CardActionArea>
               <CardMedia
                 component="img"
-                alt="여섯번째 가이드"
+                alt="여섯번째 가이드."
                 height="130"
                 image={chatImg}
                 title="guide"
@@ -205,6 +210,7 @@ export default function TutorialPage(props) {
                   className={classes.title}
                   color="textSecondary"
                   gutterBottom
+                  aria-hidden="true"
                 >
                   시작 가이드 6
                 </Typography>
@@ -226,7 +232,7 @@ export default function TutorialPage(props) {
             <CardActionArea>
               <CardMedia
                 component="img"
-                alt="일곱번째 가이드"
+                alt="일곱번째 가이드."
                 height="130"
                 image={payImg}
                 title="guide"
@@ -236,6 +242,7 @@ export default function TutorialPage(props) {
                   className={classes.title}
                   color="textSecondary"
                   gutterBottom
+                  aria-hidden="true"
                 >
                   시작 가이드 7
                 </Typography>
@@ -257,7 +264,7 @@ export default function TutorialPage(props) {
             <CardActionArea>
               <CardMedia
                 component="img"
-                alt="여덟번째 가이드"
+                alt="여덟번째 가이드."
                 height="130"
                 image={byeImg}
                 title="guide"
@@ -267,6 +274,7 @@ export default function TutorialPage(props) {
                   className={classes.title}
                   color="textSecondary"
                   gutterBottom
+                  aria-hidden="true"
                 >
                   시작 가이드 8
                 </Typography>


### PR DESCRIPTION
1. 전맹장애인이 읽을 수 없는 이미지는 대체텍스트를 첨부하지 않고 aria-hidden="true" 속성을 주어 스와이프시 자동 스킵하게 변경했습니다.
2. 앱 바 kiWE 버튼의 대체텍스트가 그냥 키위 로고로 되어있었는데, aria-label="키위 홈으로" 속성을 추가하여 기능을 알기 편하게 만들었습니다.
3. 랜딩페이지 첫머리 텍스트인 kiosk we를 TTS가 카이오스크 위로 읽어주는 오류가 발생해, aria-label="키오스크 위"로 지정해 제대로 읽어주도록 변경했습니다.
4. 채팅창 우하단 메시지 보내기버튼에 aria-label 속성 추가해 "메시지 보내기"로 읽어주게 했습니다.
5. 튜토리얼페이지 n번째 가이드 바로 다음에 휴지 없이 시작가이드 n을 읽고 가이드 텍스트 읽어주던 걸 -> n번째 가이드 후 잠깐 쉬고 가이드텍스트 바로 읽어주는 걸로 변경